### PR TITLE
main: Disable global hotkeys on Wayland

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -607,7 +607,8 @@ static void ls_app_window_init(LSAppWindow* win)
     g_signal_connect(win, "configure-event",
         G_CALLBACK(ls_app_window_resize), win);
 
-    if (win->global_hotkeys) {
+    // As a crash workaround, only enable global hotkeys if not on Wayland
+    if (win->global_hotkeys && !getenv("WAYLAND_DISPLAY")) {
         keybinder_init();
         keybinder_bind(
             g_settings_get_string(settings, "keybind-start-split"),


### PR DESCRIPTION
Port from paoloose's urn,
This is a workaround, only allowing global hotkeys to be handled in an X11 session to avoid a segfault (crash)